### PR TITLE
add doop-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BININFO_VERSION     ?= $(shell git describe --tags --always --abbrev=7)
 BININFO_COMMIT_HASH ?= $(shell git rev-parse --verify HEAD)
 BININFO_BUILD_DATE  ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-build-all: build/doop-agent build/doop-analyzer build/doop-central build/doop-image-checker build/helm-manifest-generator build/helm-manifest-parser
+build-all: build/doop-agent build/doop-analyzer build/doop-central build/doop-api build/doop-image-checker build/helm-manifest-generator build/helm-manifest-parser
 
 build/doop-agent: FORCE
 	go build $(GO_BUILDFLAGS) -ldflags '-s -w -X github.com/sapcc/go-api-declarations/bininfo.binName=doop-agent -X github.com/sapcc/go-api-declarations/bininfo.version=$(BININFO_VERSION) -X github.com/sapcc/go-api-declarations/bininfo.commit=$(BININFO_COMMIT_HASH) -X github.com/sapcc/go-api-declarations/bininfo.buildDate=$(BININFO_BUILD_DATE) $(GO_LDFLAGS)' -o build/doop-agent ./doop-agent
@@ -34,6 +34,9 @@ build/doop-analyzer: FORCE
 
 build/doop-central: FORCE
 	go build $(GO_BUILDFLAGS) -ldflags '-s -w -X github.com/sapcc/go-api-declarations/bininfo.binName=doop-central -X github.com/sapcc/go-api-declarations/bininfo.version=$(BININFO_VERSION) -X github.com/sapcc/go-api-declarations/bininfo.commit=$(BININFO_COMMIT_HASH) -X github.com/sapcc/go-api-declarations/bininfo.buildDate=$(BININFO_BUILD_DATE) $(GO_LDFLAGS)' -o build/doop-central ./doop-central
+
+build/doop-api: FORCE
+	go build $(GO_BUILDFLAGS) -ldflags '-s -w -X github.com/sapcc/go-api-declarations/bininfo.binName=doop-api -X github.com/sapcc/go-api-declarations/bininfo.version=$(BININFO_VERSION) -X github.com/sapcc/go-api-declarations/bininfo.commit=$(BININFO_COMMIT_HASH) -X github.com/sapcc/go-api-declarations/bininfo.buildDate=$(BININFO_BUILD_DATE) $(GO_LDFLAGS)' -o build/doop-api ./doop-api
 
 build/doop-image-checker: FORCE
 	go build $(GO_BUILDFLAGS) -ldflags '-s -w -X github.com/sapcc/go-api-declarations/bininfo.binName=doop-image-checker -X github.com/sapcc/go-api-declarations/bininfo.version=$(BININFO_VERSION) -X github.com/sapcc/go-api-declarations/bininfo.commit=$(BININFO_COMMIT_HASH) -X github.com/sapcc/go-api-declarations/bininfo.buildDate=$(BININFO_BUILD_DATE) $(GO_LDFLAGS)' -o build/doop-image-checker ./doop-image-checker
@@ -51,13 +54,15 @@ else
 	PREFIX = /usr
 endif
 
-install: FORCE build/doop-agent build/doop-analyzer build/doop-central build/doop-image-checker build/helm-manifest-generator build/helm-manifest-parser
+install: FORCE build/doop-agent build/doop-analyzer build/doop-central build/doop-api build/doop-image-checker build/helm-manifest-generator build/helm-manifest-parser
 	install -d -m 0755 "$(DESTDIR)$(PREFIX)/bin"
 	install -m 0755 build/doop-agent "$(DESTDIR)$(PREFIX)/bin/doop-agent"
 	install -d -m 0755 "$(DESTDIR)$(PREFIX)/bin"
 	install -m 0755 build/doop-analyzer "$(DESTDIR)$(PREFIX)/bin/doop-analyzer"
 	install -d -m 0755 "$(DESTDIR)$(PREFIX)/bin"
 	install -m 0755 build/doop-central "$(DESTDIR)$(PREFIX)/bin/doop-central"
+	install -d -m 0755 "$(DESTDIR)$(PREFIX)/bin"
+	install -m 0755 build/doop-api "$(DESTDIR)$(PREFIX)/bin/doop-api"
 	install -d -m 0755 "$(DESTDIR)$(PREFIX)/bin"
 	install -m 0755 build/doop-image-checker "$(DESTDIR)$(PREFIX)/bin/doop-image-checker"
 	install -d -m 0755 "$(DESTDIR)$(PREFIX)/bin"
@@ -137,6 +142,7 @@ help: FORCE
 	@printf "  \e[36mbuild/doop-agent\e[0m               Build doop-agent.\n"
 	@printf "  \e[36mbuild/doop-analyzer\e[0m            Build doop-analyzer.\n"
 	@printf "  \e[36mbuild/doop-central\e[0m             Build doop-central.\n"
+	@printf "  \e[36mbuild/doop-api\e[0m                 Build doop-api.\n"
 	@printf "  \e[36mbuild/doop-image-checker\e[0m       Build doop-image-checker.\n"
 	@printf "  \e[36mbuild/helm-manifest-generator\e[0m  Build helm-manifest-generator.\n"
 	@printf "  \e[36mbuild/helm-manifest-parser\e[0m     Build helm-manifest-parser.\n"

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -13,6 +13,9 @@ binaries:
   - name:        doop-central
     fromPackage: ./doop-central
     installTo:   bin/
+  - name:        doop-api
+    fromPackage: ./doop-api
+    installTo:   bin/
   - name:        doop-image-checker
     fromPackage: ./doop-image-checker
     installTo:   bin/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # gatekeeper-addons
 
-Custom addons for our setup of [Open Policy Agent's Gatekeeper](https://github.com/open-policy-agent/gatekeeper). Check the README files in the subdirectories for details.
+Custom addons for our setup of [Open Policy Agent's Gatekeeper](https://github.com/open-policy-agent/gatekeeper).
+The most significant addons is DOOP (Decentralized Observer of Policies), a system for aggregating gatekeeper-audit reports across multiple clusters.
+
+Check the README files in the subdirectories for further details.

--- a/doop-api/README.md
+++ b/doop-api/README.md
@@ -1,0 +1,46 @@
+# doop-api
+
+Takes in audit reports from multiple instances of [doop-analyzer](../doop-analyzer/) and presents them in a single API.
+
+This is the successor to doop-central (which did the same with doop-agent reports).
+The API endpoints of doop-api start in `/v2/` to distinguish it from its predecessor.
+
+## Usage
+
+The central itself is completely stateless, but some configuration must be provided in environment variables:
+
+| Variable | Default | Explanation |
+| -------- | ------- | ----------- |
+| `DOOP_API_LISTEN_ADDRESS` | `:8080` | Listen address for the HTTP server where the API is exposed. |
+| `DOOP_API_SWIFT_CONTAINER` | *(required)* | Name of the Swift container where reports were uploaded to. |
+| `DOOP_API_OBJECT_IDENTITY_LABELS` | *(empty)* | Whitespace-separated list of keys whose values will be carried over from `object_identity` into the label set of the violation count metrics (see below). |
+| `OS_...` | *(required)* | A full set of OpenStack auth environment variables, with permissions for reading from the Swift container. See [documentation for openstackclient][os-env] for details. |
+
+[os-env]: https://docs.openstack.org/python-openstackclient/latest/cli/man/openstack.html
+
+## API endpoints
+
+### GET /v2/violations
+
+Returns the full report with all violations, grouped as much as possible. The report can be filtered with the following query arguments:
+
+| Query variable | Explanation |
+| -------------- | ----------- |
+| `cluster_identity.$KEY` | Only show violations in clusters where `cluster_identity[$KEY]` is equal to the provided value. |
+| `object_identity.$KEY` | Only show violations for objects where `object_identity[$KEY]` is equal to the provided value. |
+| `template_kind` | Only show violations of constraints whose template kind is equal to the provided value. |
+| `constraint_name` | Only show violations of constraints whose name is equal to the provided value. |
+
+Each query variable can be given multiple times, in which case violations need to match any of the provided values.
+
+### GET /metrics
+
+Provides Prometheus metrics.
+
+| Metric | Explanation |
+| ------ | ----------- |
+| `doop_raw_violations` | Number of raw violations, grouped by constraint, source cluster and selected object identity labels. |
+| `doop_grouped_violations` | Number of violation groups, grouped by constraint, source cluster and selected object identity labels. |
+| `doop_oldest_audit_age_seconds` | Data age for each source cluster. |
+
+"Selected object identity labels" refers to those specified in `DOOP_API_OBJECT_IDENTITY_LABELS` (see above).

--- a/doop-api/aggregate.go
+++ b/doop-api/aggregate.go
@@ -1,0 +1,140 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+import "github.com/sapcc/gatekeeper-addons/internal/doop"
+
+// AggregateReports assembles a set of individual reports into an AggregatedReport.
+func AggregateReports(reports map[string]doop.Report, f FilterSet) doop.AggregatedReport {
+	target := doop.AggregatedReport{
+		ClusterIdentities: make(map[string]map[string]string),
+	}
+
+	for clusterName, clusterReport := range reports {
+		visitClusterReport(&target, clusterReport, clusterName, f)
+	}
+
+	return target
+}
+
+// NOTE on the general implementation style: This uses a variant of the visitor pattern.
+// For each level that is processed, we have one function to avoid nesting loops too deeply within any one function.
+// To keep the output compact, we only add objects to lists if the lower levels of the call stack actually insert data.
+// We generally try to avoid heap allocations as much as possible for temporary objects because the nested loops make the inner functions very hot.
+
+func visitClusterReport(target *doop.AggregatedReport, clusterReport doop.Report, clusterName string, f FilterSet) {
+	if !f.MatchClusterIdentity(clusterReport.ClusterIdentity) {
+		return
+	}
+
+	target.ClusterIdentities[clusterName] = clusterReport.ClusterIdentity
+	for _, tr := range clusterReport.Templates {
+		visitTemplateReport(target, tr, clusterName, f)
+	}
+}
+
+func visitTemplateReport(target *doop.AggregatedReport, tr doop.ReportForTemplate, clusterName string, f FilterSet) {
+	if !f.MatchTemplateKind(tr.Kind) {
+		return
+	}
+
+	//try to merge into existing ReportForTemplate
+	for idx, candidate := range target.Templates {
+		if candidate.Kind == tr.Kind {
+			for _, cr := range tr.Constraints {
+				visitConstraintReport(&target.Templates[idx], cr, clusterName, f)
+			}
+			return
+		}
+	}
+
+	//otherwise try to start a new ReportForTemplate
+	newReport := doop.ReportForTemplate{
+		Kind: tr.Kind,
+	}
+	for _, cr := range tr.Constraints {
+		visitConstraintReport(&newReport, cr, clusterName, f)
+	}
+	if len(newReport.Constraints) > 0 {
+		target.Templates = append(target.Templates, newReport)
+	}
+}
+
+func visitConstraintReport(target *doop.ReportForTemplate, cr doop.ReportForConstraint, clusterName string, f FilterSet) {
+	if !f.MatchConstraintName(cr.Name) {
+		return
+	}
+
+	//the Metadata.AuditTimestamp field is only used to generate Prometheus metrics; it is not aggregated
+	metadata := cr.Metadata
+	metadata.AuditTimestamp = ""
+
+	//try to merge into existing ReportForConstraint
+	for idx, candidate := range target.Constraints {
+		if candidate.Name == cr.Name && candidate.Metadata == metadata {
+			for _, vg := range cr.ViolationGroups {
+				visitViolationGroup(&target.Constraints[idx], vg, clusterName, f)
+			}
+			return
+		}
+	}
+
+	//otherwise try to start a new ReportForConstraint
+	newReport := doop.ReportForConstraint{
+		Name:     cr.Name,
+		Metadata: metadata,
+	}
+	for _, vg := range cr.ViolationGroups {
+		visitViolationGroup(&newReport, vg, clusterName, f)
+	}
+	if len(newReport.ViolationGroups) > 0 {
+		target.Constraints = append(target.Constraints, newReport)
+	}
+}
+
+func visitViolationGroup(target *doop.ReportForConstraint, vg doop.ViolationGroup, clusterName string, f FilterSet) {
+	if !f.MatchObjectIdentity(vg.Pattern.ObjectIdentity) {
+		return
+	}
+
+	//try to merge into existing ViolationGroup
+	for idx, candidate := range target.ViolationGroups {
+		if candidate.Pattern.IsEqualTo(vg.Pattern) {
+			for _, instance := range vg.Instances {
+				clonedInstance := instance.Cloned()
+				clonedInstance.ClusterName = clusterName
+				target.ViolationGroups[idx].Instances = append(candidate.Instances, clonedInstance)
+			}
+			return
+		}
+	}
+
+	//otherwise start a new ViolationGroup
+	newGroup := doop.ViolationGroup{
+		Pattern:   vg.Pattern.Cloned(),
+		Instances: make([]doop.Violation, len(vg.Instances)),
+	}
+	for idx, instance := range vg.Instances {
+		clonedInstance := instance.Cloned()
+		clonedInstance.ClusterName = clusterName
+		newGroup.Instances[idx] = clonedInstance
+	}
+	target.ViolationGroups = append(target.ViolationGroups, newGroup)
+}

--- a/doop-api/aggregate_test.go
+++ b/doop-api/aggregate_test.go
@@ -38,16 +38,19 @@ func TestAggregateOfOneCluster(t *testing.T) {
 	//test that aggregating results from only one cluster barely changes the input if no filter is applied
 	expected := mustParseJSON[doop.AggregatedReport](t, "fixtures/output-cluster1-only.json")
 	actual := AggregateReports(inputSet, BuildFilterSet(url.Values{}))
+	actual.Sort()
 	assert.DeepEqual(t, "AggregateReports", actual, expected)
 
 	//test a filter that does not change anything because it exactly matches what is in the report
 	filterStr := "cluster_identity.number=one&template_kind=GkFirstTemplate&constraint_name=firstconstraint&object_identity.type=production"
 	actual = AggregateReports(inputSet, BuildFilterSet(query(filterStr)))
+	actual.Sort()
 	assert.DeepEqual(t, "AggregateReports", actual, expected)
 
 	//test a filter that removes all clusters
 	filterStr = "cluster_identity.number=two"
 	actual = AggregateReports(inputSet, BuildFilterSet(query(filterStr)))
+	actual.Sort()
 	assert.DeepEqual(t, "AggregateReports", actual, doop.AggregatedReport{
 		ClusterIdentities: map[string]map[string]string{},
 		Templates:         nil,
@@ -62,6 +65,7 @@ func TestAggregateOfOneCluster(t *testing.T) {
 	}
 	for _, filterStr := range negativeFilters {
 		actual = AggregateReports(inputSet, BuildFilterSet(query(filterStr)))
+		actual.Sort()
 		assert.DeepEqual(t, "AggregateReports", actual, doop.AggregatedReport{
 			ClusterIdentities: map[string]map[string]string{
 				"cluster1": {"number": "one"},
@@ -86,6 +90,7 @@ func TestAggregateOfTwoClusters(t *testing.T) {
 	//test merging of structures on all levels of the report
 	expected := mustParseJSON[doop.AggregatedReport](t, "fixtures/output-both-clusters.json")
 	actual := AggregateReports(inputSet, BuildFilterSet(url.Values{}))
+	actual.Sort()
 	assert.DeepEqual(t, "AggregateReports", actual, expected)
 }
 

--- a/doop-api/aggregate_test.go
+++ b/doop-api/aggregate_test.go
@@ -1,0 +1,111 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/sapcc/go-bits/assert"
+
+	"github.com/sapcc/gatekeeper-addons/internal/doop"
+)
+
+func TestAggregateOfOneCluster(t *testing.T) {
+	inputSet := map[string]doop.Report{
+		"cluster1": mustParseJSON[doop.Report](t, "fixtures/input-cluster1.json"),
+	}
+
+	//test that aggregating results from only one cluster barely changes the input if no filter is applied
+	expected := mustParseJSON[doop.AggregatedReport](t, "fixtures/output-cluster1-only.json")
+	actual := AggregateReports(inputSet, BuildFilterSet(url.Values{}))
+	assert.DeepEqual(t, "AggregateReports", actual, expected)
+
+	//test a filter that does not change anything because it exactly matches what is in the report
+	filterStr := "cluster_identity.number=one&template_kind=GkFirstTemplate&constraint_name=firstconstraint&object_identity.type=production"
+	actual = AggregateReports(inputSet, BuildFilterSet(query(filterStr)))
+	assert.DeepEqual(t, "AggregateReports", actual, expected)
+
+	//test a filter that removes all clusters
+	filterStr = "cluster_identity.number=two"
+	actual = AggregateReports(inputSet, BuildFilterSet(query(filterStr)))
+	assert.DeepEqual(t, "AggregateReports", actual, doop.AggregatedReport{
+		ClusterIdentities: map[string]map[string]string{},
+		Templates:         nil,
+	})
+
+	//test several filters that remove all violations because they mismatch on each other possible level
+	//(removing violations also removes all effectively empty objects above it)
+	negativeFilters := []string{
+		"template_kind=GkSecondTemplate",
+		"constraint_name=secondconstraint",
+		"object_identity.type=qa",
+	}
+	for _, filterStr := range negativeFilters {
+		actual = AggregateReports(inputSet, BuildFilterSet(query(filterStr)))
+		assert.DeepEqual(t, "AggregateReports", actual, doop.AggregatedReport{
+			ClusterIdentities: map[string]map[string]string{
+				"cluster1": {"number": "one"},
+			},
+			Templates: nil,
+		})
+	}
+}
+
+func TestAggregateOfTwoClusters(t *testing.T) {
+	//Each of these cluster reports has exactly one violation.
+	inputSet := map[string]doop.Report{
+		"cluster1": mustParseJSON[doop.Report](t, "fixtures/input-cluster1.json"),
+		//this one can merge with cluster 1 on same violation group
+		"cluster2": mustParseJSON[doop.Report](t, "fixtures/input-cluster2.json"),
+		//this one can merge with cluster 1 on different violation group, but same constraint
+		"cluster3": mustParseJSON[doop.Report](t, "fixtures/input-cluster3.json"),
+		//this one can merge with cluster 1 on different constraint, but same template
+		"cluster4": mustParseJSON[doop.Report](t, "fixtures/input-cluster4.json"),
+	}
+
+	//test merging of structures on all levels of the report
+	expected := mustParseJSON[doop.AggregatedReport](t, "fixtures/output-both-clusters.json")
+	actual := AggregateReports(inputSet, BuildFilterSet(url.Values{}))
+	assert.DeepEqual(t, "AggregateReports", actual, expected)
+}
+
+func query(input string) url.Values {
+	result, err := url.ParseQuery(input)
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+func mustParseJSON[T any](t *testing.T, path string) (result T) {
+	t.Helper()
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = json.Unmarshal(buf, &result)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	return result
+}

--- a/doop-api/api.go
+++ b/doop-api/api.go
@@ -1,0 +1,51 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/sapcc/go-bits/httpapi"
+	"github.com/sapcc/go-bits/respondwith"
+)
+
+// API is an httpapi.API implementation.
+type API struct {
+	Downloader *Downloader
+}
+
+// AddTo implements the httpapi.API interface.
+func (a API) AddTo(r *mux.Router) {
+	r.Methods("GET").Path("/v2/violations").HandlerFunc(a.handleGetViolations)
+}
+
+func (a API) handleGetViolations(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v2/violations")
+
+	reports, err := a.Downloader.GetReports()
+	if respondwith.ErrorText(w, err) {
+		return
+	}
+
+	//TODO dummy implementation
+	http.Error(w, fmt.Sprintf("There are %d reports.", len(reports)), http.StatusOK)
+}

--- a/doop-api/api.go
+++ b/doop-api/api.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -45,7 +44,7 @@ func (a API) handleGetViolations(w http.ResponseWriter, r *http.Request) {
 	if respondwith.ErrorText(w, err) {
 		return
 	}
-
-	//TODO dummy implementation
-	http.Error(w, fmt.Sprintf("There are %d reports.", len(reports)), http.StatusOK)
+	result := AggregateReports(reports, BuildFilterSet(r.URL.Query()))
+	result.Sort()
+	respondwith.JSON(w, http.StatusOK, result)
 }

--- a/doop-api/downloader.go
+++ b/doop-api/downloader.go
@@ -1,0 +1,104 @@
+/*******************************************************************************
+*
+* Copyright 2021-2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/majewsky/schwift"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/gatekeeper-addons/internal/doop"
+)
+
+// Downloader pulls doop-agent reports from Swift.
+type Downloader struct {
+	container *schwift.Container
+	objects   map[string]*objectState
+	mutex     sync.Mutex
+}
+
+// NewDownloader creates a Downloader.
+func NewDownloader(container *schwift.Container) *Downloader {
+	return &Downloader{
+		container: container,
+		objects:   make(map[string]*objectState),
+	}
+}
+
+// GetReports returns all most recent doop-agent reports in their yet unparsed form.
+func (d *Downloader) GetReports() (map[string]doop.Report, error) {
+	objInfos, err := d.container.Objects().CollectDetailed()
+	if err != nil {
+		return nil, fmt.Errorf("cannot list reports in Swift: %w", err)
+	}
+
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	result := make(map[string]doop.Report, len(objInfos))
+	for _, oi := range objInfos {
+		name := oi.Object.Name()
+		os := d.objects[name]
+
+		if os.NeedsUpdate(oi) {
+			logg.Debug("pulling updated report for %s", name)
+			if os == nil {
+				os = &objectState{}
+				d.objects[name] = os
+			}
+			os.SizeBytes = oi.SizeBytes
+			os.Etag = oi.Etag
+			os.LastModified = oi.LastModified
+			payloadBytes, err := oi.Object.Download(nil).AsByteSlice()
+			if err != nil {
+				return nil, fmt.Errorf("cannot download report for %s from Swift: %w", name, err)
+			}
+			var payload doop.Report
+			err = json.Unmarshal(payloadBytes, &payload)
+			if err != nil {
+				return nil, fmt.Errorf("cannot decode report for %s: %w", name, err)
+			}
+			os.Payload = payload
+		}
+
+		result[name] = os.Payload
+	}
+
+	return result, nil
+}
+
+type objectState struct {
+	SizeBytes    uint64
+	Etag         string
+	LastModified time.Time
+	Payload      doop.Report
+}
+
+func (os *objectState) NeedsUpdate(oi schwift.ObjectInfo) bool {
+	//if we don't have any state locally yet, we definitely need to update
+	if os == nil {
+		return true
+	}
+	return os.SizeBytes != oi.SizeBytes || os.Etag != oi.Etag || os.LastModified != oi.LastModified
+}

--- a/doop-api/filter.go
+++ b/doop-api/filter.go
@@ -1,0 +1,99 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+// FilterSet describes which clusters/templates/constraints/violations to filter out when aggregating reports.
+type FilterSet struct {
+	clusterIdentity map[string]filter
+	templateKind    filter
+	constraintName  filter
+	objectIdentity  map[string]filter
+}
+
+// BuildFilterSet collects filter settings from the given URL query.
+func BuildFilterSet(query url.Values) FilterSet {
+	return FilterSet{
+		clusterIdentity: buildMapFilter(query, "cluster_identity."),
+		templateKind:    filter(query["template_kind"]),
+		constraintName:  filter(query["constraint_name"]),
+		objectIdentity:  buildMapFilter(query, "object_identity."),
+	}
+}
+
+func buildMapFilter(query url.Values, prefix string) map[string]filter {
+	result := make(map[string]filter)
+	for queryKey, values := range query {
+		if strings.HasPrefix(queryKey, prefix) {
+			key := strings.TrimPrefix(queryKey, prefix)
+			result[key] = filter(values)
+		}
+	}
+	return result
+}
+
+// MatchClusterIdentity checks whether a cluster with the given identity shall be included in the result.
+func (fs FilterSet) MatchClusterIdentity(identity map[string]string) bool {
+	for key, filter := range fs.clusterIdentity {
+		if !filter.match(identity[key]) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchObjectIdentity checks whether a violation with the given object identity shall be included in the result.
+func (fs FilterSet) MatchObjectIdentity(identity map[string]string) bool {
+	for key, filter := range fs.objectIdentity {
+		if !filter.match(identity[key]) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchTemplateKind checks whether a constraint template with the given kind shall be included in the result.
+func (fs FilterSet) MatchTemplateKind(kind string) bool {
+	return fs.templateKind.match(kind)
+}
+
+// MatchConstraintName checks whether a constraint with the given name shall be included in the result.
+func (fs FilterSet) MatchConstraintName(name string) bool {
+	return fs.constraintName.match(name)
+}
+
+// A list of allowed values for a certain field. If the list is empty, all values are allowed.
+type filter []string
+
+func (f filter) match(givenValue string) bool {
+	if len(f) == 0 {
+		return true
+	}
+	for _, allowedValue := range f {
+		if allowedValue == givenValue {
+			return true
+		}
+	}
+	return false
+}

--- a/doop-api/fixtures/input-cluster1.json
+++ b/doop-api/fixtures/input-cluster1.json
@@ -1,0 +1,37 @@
+{
+  "cluster_identity": {
+    "number": "one"
+  },
+  "templates": [
+    {
+      "kind": "GkFirstTemplate",
+      "constraints": [
+        {
+          "name": "firstconstraint",
+          "metadata": {
+            "severity": "info",
+            "auditTimestamp": "2023-09-05T09:24:27Z"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-violations-across-clusters",
+                "message": "this is from <cluster>",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "message": "this is from cluster1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/doop-api/fixtures/input-cluster2.json
+++ b/doop-api/fixtures/input-cluster2.json
@@ -1,0 +1,37 @@
+{
+  "cluster_identity": {
+    "number": "two"
+  },
+  "templates": [
+    {
+      "kind": "GkFirstTemplate",
+      "constraints": [
+        {
+          "name": "firstconstraint",
+          "metadata": {
+            "severity": "info",
+            "auditTimestamp": "2023-09-05T09:24:28Z"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-violations-across-clusters",
+                "message": "this is from <cluster>",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "message": "this is from cluster2"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/doop-api/fixtures/input-cluster3.json
+++ b/doop-api/fixtures/input-cluster3.json
@@ -1,0 +1,35 @@
+{
+  "cluster_identity": {
+    "number": "three"
+  },
+  "templates": [
+    {
+      "kind": "GkFirstTemplate",
+      "constraints": [
+        {
+          "name": "firstconstraint",
+          "metadata": {
+            "severity": "info",
+            "auditTimestamp": "2023-09-05T09:24:29Z"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-violation-groups-inside-constraint",
+                "message": "this is in another violation group",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/doop-api/fixtures/input-cluster4.json
+++ b/doop-api/fixtures/input-cluster4.json
@@ -1,0 +1,35 @@
+{
+  "cluster_identity": {
+    "number": "four"
+  },
+  "templates": [
+    {
+      "kind": "GkFirstTemplate",
+      "constraints": [
+        {
+          "name": "secondconstraint",
+          "metadata": {
+            "severity": "info",
+            "auditTimestamp": "2023-09-05T09:24:30Z"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-constraint-inside-templates",
+                "message": "this is in another constraint",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/doop-api/fixtures/output-both-clusters.json
+++ b/doop-api/fixtures/output-both-clusters.json
@@ -27,6 +27,22 @@
               "pattern": {
                 "kind": "Pod",
                 "namespace": "test",
+                "name": "merge-violation-groups-inside-constraint",
+                "message": "this is in another violation group",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "cluster": "cluster3"
+                }
+              ]
+            },
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
                 "name": "merge-violations-across-clusters",
                 "message": "this is from <cluster>",
                 "object_identity": {
@@ -41,22 +57,6 @@
                 {
                   "message": "this is from cluster2",
                   "cluster": "cluster2"
-                }
-              ]
-            },
-            {
-              "pattern": {
-                "kind": "Pod",
-                "namespace": "test",
-                "name": "merge-violation-groups-inside-constraint",
-                "message": "this is in another violation group",
-                "object_identity": {
-                  "type": "production"
-                }
-              },
-              "instances": [
-                {
-                  "cluster": "cluster3"
                 }
               ]
             }

--- a/doop-api/fixtures/output-both-clusters.json
+++ b/doop-api/fixtures/output-both-clusters.json
@@ -1,0 +1,92 @@
+{
+  "cluster_identities": {
+    "cluster1": {
+      "number": "one"
+    },
+    "cluster2": {
+      "number": "two"
+    },
+    "cluster3": {
+      "number": "three"
+    },
+    "cluster4": {
+      "number": "four"
+    }
+  },
+  "templates": [
+    {
+      "kind": "GkFirstTemplate",
+      "constraints": [
+        {
+          "name": "firstconstraint",
+          "metadata": {
+            "severity": "info"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-violations-across-clusters",
+                "message": "this is from <cluster>",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "message": "this is from cluster1",
+                  "cluster": "cluster1"
+                },
+                {
+                  "message": "this is from cluster2",
+                  "cluster": "cluster2"
+                }
+              ]
+            },
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-violation-groups-inside-constraint",
+                "message": "this is in another violation group",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "cluster": "cluster3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "secondconstraint",
+          "metadata": {
+            "severity": "info"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-constraint-inside-templates",
+                "message": "this is in another constraint",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "cluster": "cluster4"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/doop-api/fixtures/output-cluster1-only.json
+++ b/doop-api/fixtures/output-cluster1-only.json
@@ -1,0 +1,39 @@
+{
+  "cluster_identities": {
+    "cluster1": {
+      "number": "one"
+    }
+  },
+  "templates": [
+    {
+      "kind": "GkFirstTemplate",
+      "constraints": [
+        {
+          "name": "firstconstraint",
+          "metadata": {
+            "severity": "info"
+          },
+          "violation_groups": [
+            {
+              "pattern": {
+                "kind": "Pod",
+                "namespace": "test",
+                "name": "merge-violations-across-clusters",
+                "message": "this is from <cluster>",
+                "object_identity": {
+                  "type": "production"
+                }
+              },
+              "instances": [
+                {
+                  "message": "this is from cluster1",
+                  "cluster": "cluster1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/doop-api/main.go
+++ b/doop-api/main.go
@@ -19,5 +19,57 @@
 
 package main
 
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/majewsky/schwift/gopherschwift"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sapcc/go-api-declarations/bininfo"
+	"github.com/sapcc/go-bits/httpapi"
+	"github.com/sapcc/go-bits/httpapi/pprofapi"
+	"github.com/sapcc/go-bits/httpext"
+	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/must"
+	"github.com/sapcc/go-bits/osext"
+	"go.uber.org/automaxprocs/maxprocs"
+)
+
 func main() {
+	logg.ShowDebug = osext.GetenvBool("DOOP_API_DEBUG")
+	undoMaxprocs := must.Return(maxprocs.Set(maxprocs.Logger(logg.Debug)))
+	defer undoMaxprocs()
+
+	wrap := httpext.WrapTransport(&http.DefaultTransport)
+	wrap.SetOverrideUserAgent(bininfo.Component(), bininfo.VersionOr("rolling"))
+
+	//initialize OpenStack/Swift client
+	ao := must.Return(clientconfig.AuthOptions(nil))
+	ao.AllowReauth = true
+	provider := must.Return(openstack.NewClient(ao.IdentityEndpoint))
+	must.Succeed(openstack.Authenticate(provider, *ao))
+	client := must.Return(openstack.NewObjectStorageV1(provider, gophercloud.EndpointOpts{}))
+	account := must.Return(gopherschwift.Wrap(client, nil))
+	containerName := osext.MustGetenv("DOOP_API_SWIFT_CONTAINER")
+	container := must.Return(account.Container(containerName).EnsureExists())
+	downloader := NewDownloader(container)
+
+	//collect HTTP handlers
+	handler := httpapi.Compose(
+		API{downloader},
+		httpapi.HealthCheckAPI{SkipRequestLog: true},
+		pprofapi.API{IsAuthorized: pprofapi.IsRequestFromLocalhost},
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/", handler)
+	mux.Handle("/metrics", promhttp.Handler()) //TODO custom metrics
+
+	//start HTTP server
+	ctx := httpext.ContextWithSIGINT(context.Background(), 10*time.Second)
+	listenAddress := osext.GetenvOrDefault("DOOP_API_LISTEN_ADDRESS", ":8080")
+	must.Succeed(httpext.ListenAndServeContext(ctx, listenAddress, mux))
 }

--- a/doop-api/main.go
+++ b/doop-api/main.go
@@ -1,0 +1,23 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+func main() {
+}

--- a/doop-api/main.go
+++ b/doop-api/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/majewsky/schwift/gopherschwift"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sapcc/go-api-declarations/bininfo"
 	"github.com/sapcc/go-bits/httpapi"
@@ -59,6 +60,7 @@ func main() {
 	downloader := NewDownloader(container)
 
 	//collect HTTP handlers
+	prometheus.MustRegister(NewMetricCollector(downloader))
 	handler := httpapi.Compose(
 		API{downloader},
 		httpapi.HealthCheckAPI{SkipRequestLog: true},
@@ -66,7 +68,7 @@ func main() {
 	)
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
-	mux.Handle("/metrics", promhttp.Handler()) //TODO custom metrics
+	mux.Handle("/metrics", promhttp.Handler())
 
 	//start HTTP server
 	ctx := httpext.ContextWithSIGINT(context.Background(), 10*time.Second)

--- a/doop-api/metrics.go
+++ b/doop-api/metrics.go
@@ -1,0 +1,201 @@
+/*******************************************************************************
+*
+* Copyright 2023 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package main
+
+import (
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-bits/logg"
+
+	"github.com/sapcc/gatekeeper-addons/internal/doop"
+)
+
+// MetricCollector is a prometheus.Collector for all metrics provided by this application.
+type MetricCollector struct {
+	downloader             *Downloader
+	objectIdentityKeys     []string
+	rawViolationsGauge     *prometheus.GaugeVec
+	groupedViolationsGauge *prometheus.GaugeVec
+	auditAgeOldestGauge    *prometheus.GaugeVec
+}
+
+// NewMetricCollector initializes a MetricCollector.
+func NewMetricCollector(downloader *Downloader) *MetricCollector {
+	objectIdentityKeys := strings.Fields(os.Getenv("DOOP_API_OBJECT_IDENTITY_LABELS"))
+
+	//the given key names may not be suitable as label names because of the restricted label name grammar
+	//-> sanitize all non-alphanumeric characters into underscores for the label names
+	objectIdentityLabels := make([]string, len(objectIdentityKeys))
+	rx := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	for idx, key := range objectIdentityKeys {
+		objectIdentityLabels[idx] = rx.ReplaceAllString(key, "_")
+	}
+
+	return &MetricCollector{
+		downloader:         downloader,
+		objectIdentityKeys: objectIdentityKeys,
+		rawViolationsGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doop_raw_violations",
+				Help: "Number of raw violations, grouped by constraint, source cluster and selected object identity labels.",
+			},
+			append([]string{"cluster", "template_kind", "constraint_name"}, objectIdentityLabels...),
+		),
+		groupedViolationsGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doop_grouped_violations",
+				Help: "Number of violation groups, grouped by constraint, source cluster and selected object identity labels.",
+			},
+			append([]string{"template_kind", "constraint_name"}, objectIdentityLabels...),
+		),
+		auditAgeOldestGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "doop_oldest_audit_age_seconds",
+				Help: "Data age for each source cluster.",
+			},
+			[]string{"cluster"},
+		),
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (mc *MetricCollector) Describe(ch chan<- *prometheus.Desc) {
+	mc.rawViolationsGauge.Describe(ch)
+	mc.groupedViolationsGauge.Describe(ch)
+	mc.auditAgeOldestGauge.Describe(ch)
+}
+
+// Collect implements the prometheus.Collector interface.
+func (mc *MetricCollector) Collect(ch chan<- prometheus.Metric) {
+	descCh := make(chan *prometheus.Desc, 1)
+	mc.rawViolationsGauge.Describe(descCh)
+	rawViolationsDesc := <-descCh
+	mc.groupedViolationsGauge.Describe(descCh)
+	groupedViolationsDesc := <-descCh
+	mc.auditAgeOldestGauge.Describe(descCh)
+	auditAgeOldestDesc := <-descCh
+
+	//using the individual reports, we can immediately calculate the audit age
+	reports, err := mc.downloader.GetReports()
+	if err != nil {
+		logg.Error("could not download reports for metric computation: %s", err.Error())
+	}
+	for clusterName, report := range reports {
+		ch <- prometheus.MustNewConstMetric(
+			auditAgeOldestDesc,
+			prometheus.GaugeValue, float64(oldestAuditTimestampForClusterReport(clusterName, report)),
+			clusterName,
+		)
+	}
+
+	//counting violation groups requires an aggregated report
+	fullReport := AggregateReports(reports, BuildFilterSet(url.Values{}))
+	for _, rt := range fullReport.Templates {
+		for _, rc := range rt.Constraints {
+			countViolationsForConstraint(rt.Kind, rc, mc.objectIdentityKeys, rawViolationsDesc, groupedViolationsDesc, ch)
+		}
+	}
+}
+
+func oldestAuditTimestampForClusterReport(clusterName string, report doop.Report) int64 {
+	result := int64(-1)
+	for _, rt := range report.Templates {
+		for _, rc := range rt.Constraints {
+			auditTimeStr := rc.Metadata.AuditTimestamp
+			if auditTimeStr == "" {
+				continue
+			}
+
+			auditTime, err := time.Parse(time.RFC3339, auditTimeStr)
+			if err != nil {
+				logg.Error("cannot parse audit timestamp %q for cluster %s: %s",
+					auditTimeStr, clusterName, err.Error())
+				//to ensure that the error is noticed, report a very old timestamp that likely triggers alerts
+				return 0
+			}
+
+			unixTime := auditTime.Unix()
+			if result == -1 || result > unixTime {
+				result = unixTime
+			}
+		}
+	}
+	return result
+}
+
+func countViolationsForConstraint(templateKind string, rc doop.ReportForConstraint, oidKeys []string, rawViolationsDesc, groupedViolationsDesc *prometheus.Desc, ch chan<- prometheus.Metric) {
+	//NOTE: This function uses "oid" as an abbreviation for "object identity".
+
+	//First map key is the relevant oid values, second map key is the cluster name.
+	//Since we do not know how many oid keys we will have in advance, we merge them all together into one string with "\0" as a field separator.
+	rawCounts := make(map[string]map[string]int)
+	//No cluster name here, only the relevant oid values.
+	groupedCounts := make(map[string]int)
+
+	//count violations and violation groups
+	for _, vg := range rc.ViolationGroups {
+		oidValues := make([]string, len(oidKeys))
+		for idx, key := range oidKeys {
+			oidValues[idx] = vg.Pattern.ObjectIdentity[key]
+		}
+		oidValuesStr := strings.Join(oidValues, "\000")
+
+		groupedCounts[oidValuesStr]++
+		if rawCounts[oidValuesStr] == nil {
+			rawCounts[oidValuesStr] = make(map[string]int)
+		}
+		for _, v := range vg.Instances {
+			rawCounts[oidValuesStr][v.ClusterName]++
+		}
+	}
+
+	//emit metrics
+	for oidValuesStr, count := range groupedCounts {
+		labels := make([]string, 2, 2+len(oidKeys))
+		labels[0] = templateKind
+		labels[1] = rc.Name
+		labels = append(labels, strings.Split(oidValuesStr, "\000")...)
+		ch <- prometheus.MustNewConstMetric(
+			groupedViolationsDesc,
+			prometheus.GaugeValue, float64(count),
+			labels...,
+		)
+	}
+
+	for oidValuesStr, subcounts := range rawCounts {
+		labels := make([]string, 3, 3+len(oidKeys))
+		labels[1] = templateKind
+		labels[2] = rc.Name
+		labels = append(labels, strings.Split(oidValuesStr, "\000")...)
+		for clusterName, count := range subcounts {
+			labels[0] = clusterName
+			ch <- prometheus.MustNewConstMetric(
+				rawViolationsDesc,
+				prometheus.GaugeValue, float64(count),
+				labels...,
+			)
+		}
+	}
+}

--- a/internal/doop/report.go
+++ b/internal/doop/report.go
@@ -19,7 +19,10 @@
 
 package doop
 
-import "sort"
+import (
+	"slices"
+	"strings"
+)
 
 // Report is the data structure that doop-analyzer produces.
 type Report struct {
@@ -35,8 +38,8 @@ type ReportForTemplate struct {
 
 // Sort sorts all lists in this report in the respective canonical order.
 func (r *ReportForTemplate) Sort() {
-	sort.Slice(r.Constraints, func(i, j int) bool {
-		return r.Constraints[i].Name < r.Constraints[j].Name
+	slices.SortFunc(r.Constraints, func(lhs, rhs ReportForConstraint) int {
+		return strings.Compare(lhs.Name, rhs.Name)
 	})
 	for idx := range r.Constraints {
 		r.Constraints[idx].Sort()
@@ -65,16 +68,12 @@ type MetadataForConstraint struct {
 
 // Sort sorts all lists in this report in the respective canonical order.
 func (r *ReportForConstraint) Sort() {
-	sort.Slice(r.ViolationGroups, func(i, j int) bool {
-		lhs := r.ViolationGroups[i].Pattern
-		rhs := r.ViolationGroups[j].Pattern
-		return lhs.CompareTo(rhs) < 0
+	slices.SortFunc(r.ViolationGroups, func(lhs, rhs ViolationGroup) int {
+		return lhs.Pattern.CompareTo(rhs.Pattern)
 	})
 	for _, vg := range r.ViolationGroups {
-		sort.Slice(vg.Instances, func(i, j int) bool {
-			lhs := vg.Instances[i]
-			rhs := vg.Instances[j]
-			return lhs.CompareTo(rhs) < 0
+		slices.SortFunc(vg.Instances, func(lhs, rhs Violation) int {
+			return lhs.CompareTo(rhs)
 		})
 	}
 }
@@ -88,8 +87,8 @@ type AggregatedReport struct {
 
 // Sort sorts all lists in this report in the respective canonical order.
 func (r *AggregatedReport) Sort() {
-	sort.Slice(r.Templates, func(i, j int) bool {
-		return r.Templates[i].Kind < r.Templates[j].Kind
+	slices.SortFunc(r.Templates, func(lhs, rhs ReportForTemplate) int {
+		return strings.Compare(lhs.Kind, rhs.Kind)
 	})
 	for idx := range r.Templates {
 		r.Templates[idx].Sort()

--- a/internal/doop/report.go
+++ b/internal/doop/report.go
@@ -70,6 +70,13 @@ func (r *ReportForConstraint) Sort() {
 		rhs := r.ViolationGroups[j].Pattern
 		return lhs.CompareTo(rhs) < 0
 	})
+	for _, vg := range r.ViolationGroups {
+		sort.Slice(vg.Instances, func(i, j int) bool {
+			lhs := vg.Instances[i]
+			rhs := vg.Instances[j]
+			return lhs.CompareTo(rhs) < 0
+		})
+	}
 }
 
 // AggregatedReport is the data structure that doop-api produces. It aggregates


### PR DESCRIPTION
This is the successor to doop-central, using reports from doop-analyzer instead of the older doop-agent.