### PR TITLE
doop-api: reduce allocations during AggregateReports()

### DIFF
--- a/doop-api/aggregate_test.go
+++ b/doop-api/aggregate_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestAggregateOfOneCluster(t *testing.T) {
 	inputSet := map[string]doop.Report{
-		"cluster1": mustParseJSON[doop.Report](t, "fixtures/input-cluster1.json"),
+		"cluster1": mustParseJSON[doop.Report](t, "fixtures/input-cluster1.json").SetClusterName("cluster1"),
 	}
 
 	//test that aggregating results from only one cluster barely changes the input if no filter is applied
@@ -78,13 +78,13 @@ func TestAggregateOfOneCluster(t *testing.T) {
 func TestAggregateOfTwoClusters(t *testing.T) {
 	//Each of these cluster reports has exactly one violation.
 	inputSet := map[string]doop.Report{
-		"cluster1": mustParseJSON[doop.Report](t, "fixtures/input-cluster1.json"),
+		"cluster1": mustParseJSON[doop.Report](t, "fixtures/input-cluster1.json").SetClusterName("cluster1"),
 		//this one can merge with cluster 1 on same violation group
-		"cluster2": mustParseJSON[doop.Report](t, "fixtures/input-cluster2.json"),
+		"cluster2": mustParseJSON[doop.Report](t, "fixtures/input-cluster2.json").SetClusterName("cluster2"),
 		//this one can merge with cluster 1 on different violation group, but same constraint
-		"cluster3": mustParseJSON[doop.Report](t, "fixtures/input-cluster3.json"),
+		"cluster3": mustParseJSON[doop.Report](t, "fixtures/input-cluster3.json").SetClusterName("cluster3"),
 		//this one can merge with cluster 1 on different constraint, but same template
-		"cluster4": mustParseJSON[doop.Report](t, "fixtures/input-cluster4.json"),
+		"cluster4": mustParseJSON[doop.Report](t, "fixtures/input-cluster4.json").SetClusterName("cluster4"),
 	}
 
 	//test merging of structures on all levels of the report

--- a/doop-api/downloader.go
+++ b/doop-api/downloader.go
@@ -81,6 +81,7 @@ func (d *Downloader) GetReports() (map[string]doop.Report, error) {
 			if err != nil {
 				return nil, fmt.Errorf("cannot decode report for %s: %w", name, err)
 			}
+			payload.SetClusterName(name)
 			objState.Payload = payload
 		}
 

--- a/internal/doop/report.go
+++ b/internal/doop/report.go
@@ -30,6 +30,23 @@ type Report struct {
 	Templates       []ReportForTemplate `json:"templates"`
 }
 
+// SetClusterName sets the ClusterName field on all Violation objects in this Report.
+// This is used at report loading time to prepare the report for aggregation.
+// The self-return is used to shorten setup code in unit tests.
+func (r Report) SetClusterName(clusterName string) Report {
+	for _, t := range r.Templates {
+		for _, c := range t.Constraints {
+			for _, vg := range c.ViolationGroups {
+				for idx, v := range vg.Instances {
+					v.ClusterName = clusterName
+					vg.Instances[idx] = v
+				}
+			}
+		}
+	}
+	return r
+}
+
 // ReportForTemplate appears in type Report.
 type ReportForTemplate struct {
 	Kind        string                `json:"kind"`

--- a/internal/doop/violation.go
+++ b/internal/doop/violation.go
@@ -40,6 +40,7 @@ type Violation struct {
 	Message        string            `json:"message,omitempty"`
 	ObjectIdentity map[string]string `json:"object_identity,omitempty"`
 	// This field is only set when this Violation appears as a ViolationGroup instance inside an AggregatedReport.
+	// It is written by Report.SetClusterName() at report loading time.
 	ClusterName string `json:"cluster,omitempty"`
 }
 


### PR DESCRIPTION
By filling the Violation.ClusterName attribute early (during report loading), we can avoid making explicit copies of the violations during the aggregation.