### PR TITLE
doop-{analyzer,api}: support Swift service types != object-store

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -102,6 +102,9 @@ linters:
           msg: github.com/containers/image/v5 is deprecated and was replaced with go.podman.io/image/v5
     goconst:
       min-occurrences: 5
+      ignore-tests: true
+      ignore-string-values:
+        - '^[a-zA-Z_-]{1,16}$' # ignore short identifiers like "account" or "project_id"
     gocritic:
       enabled-checks:
         - boolExprSimplify

--- a/doop-analyzer/README.md
+++ b/doop-analyzer/README.md
@@ -6,10 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 # doop-analyzer
 
 Runs in a Kubernetes cluster alongside a Gatekeeper instance. Once a minute, all template errors and audit violations
-are collected and pushed into a Swift container for further processing by [doop-central](../doop-central/).
+are collected and pushed into a Swift container for further processing by [doop-api](../doop-api/).
 
 This is the successor to doop-agent. The main difference is that it takes on some of the more computationally expensive
-analysis steps that used to be performed by doop-central.
+analysis steps that used to be performed by doop-api.
 
 ## Usage
 

--- a/doop-analyzer/README.md
+++ b/doop-analyzer/README.md
@@ -53,6 +53,7 @@ The following fields are allowed in the JSON configuration file:
 | `processing_rules` | list of objects | A sequence of rules that will be applied to each violation in order to normalize its attributes. [See below](#rule-based-rewriting) for details. Only needed for `run` and `process-once`. |
 | `swift.container_name` | string | Name of Swift container in which to upload report. Only needed for `run`. |
 | `swift.object_name` | string | Object name with which report will be uploaded in Swift. Only needed for `run`. |
+| `swift.service_type` | string | Service type for Swift in the Keystone service catalog. Defaults to `object-store` for native Swift, but can be set to e.g. `object-store-ceph` to use Ceph's Swift-compatible API. |
 
 ### Kubernetes API permissions
 

--- a/doop-analyzer/swift.go
+++ b/doop-analyzer/swift.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,7 @@ import (
 // SwiftConfiguration appears in type Configuration. It also holds the methods
 // and state for talking to Swift.
 type SwiftConfiguration struct {
+	ServiceType   string `json:"service_type"`
 	ContainerName string `json:"container_name"`
 	ObjectName    string `json:"object_name"`
 	// filled by Connect()
@@ -42,6 +44,7 @@ func (s *SwiftConfiguration) Connect(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	eo.Type = cmp.Or(s.ServiceType, "object-store")
 	client, err := openstack.NewObjectStorageV1(provider, eo)
 	if err != nil {
 		return fmt.Errorf("cannot initialize Swift client: %w", err)

--- a/doop-api/README.md
+++ b/doop-api/README.md
@@ -12,7 +12,7 @@ The API endpoints of doop-api start in `/v2/` to distinguish it from its predece
 
 ## Usage
 
-The central itself is completely stateless, but some configuration must be provided in environment variables:
+The doop-api itself is completely stateless, but some configuration must be provided in environment variables:
 
 | Variable | Default | Explanation |
 | -------- | ------- | ----------- |

--- a/doop-api/README.md
+++ b/doop-api/README.md
@@ -18,6 +18,7 @@ The central itself is completely stateless, but some configuration must be provi
 | -------- | ------- | ----------- |
 | `DOOP_API_LISTEN_ADDRESS` | `:8080` | Listen address for the HTTP server where the API is exposed. |
 | `DOOP_API_SWIFT_CONTAINER` | *(required)* | Name of the Swift container where reports were uploaded to. |
+| `DOOP_API_SWIFT_SERVICE_TYPE` | `object-store` | Service type for Swift in the Keystone service catalog. Not needed when using native Swift, but can be set to e.g. `object-store-ceph` to use Ceph's Swift-compatible API. |
 | `DOOP_API_OBJECT_IDENTITY_LABELS` | *(empty)* | Whitespace-separated list of keys whose values will be carried over from `object_identity` into the label set of the violation count metrics (see below). |
 | `OS_...` | *(required)* | A full set of OpenStack auth environment variables, with permissions for reading from the Swift container. See [documentation for openstackclient][os-env] for details. |
 

--- a/doop-api/downloader.go
+++ b/doop-api/downloader.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sapcc/gatekeeper-addons/internal/doop"
 )
 
-// Downloader pulls doop-agent reports from Swift.
+// Downloader pulls doop-analyzer reports from Swift.
 type Downloader struct {
 	container *schwift.Container
 	objects   map[string]*objectState
@@ -31,7 +31,7 @@ func NewDownloader(container *schwift.Container) *Downloader {
 	}
 }
 
-// GetReports returns all most recent doop-agent reports in their yet unparsed form.
+// GetReports returns all most recent doop-analyzer reports in their yet unparsed form.
 func (d *Downloader) GetReports(ctx context.Context) (map[string]doop.Report, error) {
 	objInfos, err := d.container.Objects().CollectDetailed(ctx)
 	if err != nil {

--- a/doop-api/main.go
+++ b/doop-api/main.go
@@ -37,6 +37,7 @@ func main() {
 	// initialize OpenStack/Swift client
 	provider, eo, err := gophercloudext.NewProviderClient(ctx, nil)
 	must.Succeed(err)
+	eo.Type = osext.GetenvOrDefault("DOOP_API_SWIFT_SERVICE_TYPE", "object-store")
 	client := must.Return(openstack.NewObjectStorageV1(provider, eo))
 	account := must.Return(gopherschwift.Wrap(client, nil))
 	containerName := osext.MustGetenv("DOOP_API_SWIFT_CONTAINER")


### PR DESCRIPTION
Once we migrate to Ceph, we need to use "object-store-ceph" instead.

Also, while I was on it, I removed references to the old component names "doop-central" and "doop-agent".